### PR TITLE
Read number of sensors from db

### DIFF
--- a/database/database.cc
+++ b/database/database.cc
@@ -52,11 +52,24 @@ void getSensorsFromDB(ReadConfig * config, next::Sensors &sensors, int run_numbe
 	MYSQL_ROW row;
 
 	int elecid, sensorid;
+	//This id separates between pmts and sipms elecIDs
+	// Sipms starts at 1000, external pmt is 99
+	int threshold = 90;
+	int npmts  = 0;
+	int nsipms = 0;
 	while ((row = mysql_fetch_row(result))){
 		elecid   = std::stoi(row[0]);
 		sensorid = std::stoi(row[1]);
 		sensors.update_relations(elecid, sensorid);
+
+		if(elecid < threshold){
+			npmts += 1;
+		}else{
+			nsipms += 1;
+		}
 	}
+	sensors.setNumberOfPmts (npmts);
+	sensors.setNumberOfSipms(nsipms);
 
 	mysql_free_result(result);
 	mysql_close(con);

--- a/database/sensors.cc
+++ b/database/sensors.cc
@@ -27,11 +27,19 @@ void next::Sensors::update_relations(int elecID, int sensorID){
 }
 
 int next::Sensors::getNumberOfPmts(){
-	return NPMT;
+	return _npmts;
 }
 
 int next::Sensors::getNumberOfSipms(){
-	return NSIPM;
+	return _nsipms;
+}
+
+void next::Sensors::setNumberOfPmts(int npmts){
+	_npmts = npmts;
+}
+
+void next::Sensors::setNumberOfSipms(int nsipms){
+	_nsipms = nsipms;
 }
 
 int SipmIDtoPosition(int id){

--- a/database/sensors.h
+++ b/database/sensors.h
@@ -17,11 +17,16 @@ namespace next{
 			int getNumberOfPmts();
 			int getNumberOfSipms();
 
+			void setNumberOfPmts (int npmts);
+			void setNumberOfSipms(int nsipms);
+
 			void update_relations(int elecID, int sensorID);
 
 		private:
 			std::map<int, int> _elecToSensor;
 			std::map<int, int> _sensorToElec;
+			int _npmts;
+			int _nsipms;
 	};
 
 }

--- a/writer/HDF5Writer.cc
+++ b/writer/HDF5Writer.cc
@@ -98,6 +98,13 @@ void next::HDF5Writer::Write(DigitCollection& pmts, DigitCollection& blrs,
 
 	_log->debug("Writing event {} to HDF5 file {}", evt_number, ifile);
 
+	// Query the DB only one time even if there are two files
+	if (!_nodb && _firstEvent[0] && _firstEvent[1]){
+		std::cout << "connecting to db" << std::endl;
+		//Load sensors data from DB
+		getSensorsFromDB(_config, _sensors, run_number, true);
+	}
+
 	//Get number of sensors
 	int total_pmts  = _sensors.getNumberOfPmts();
 	int total_blrs  = _sensors.getNumberOfPmts();
@@ -134,11 +141,6 @@ void next::HDF5Writer::Write(DigitCollection& pmts, DigitCollection& blrs,
 		extPmtDatasize = extPmt[0].nSamples();
 	}
 
-	// Query the DB only one time even if there are two files
-	if (_firstEvent[0] && _firstEvent[1]){
-		//Load sensors data from DB
-		getSensorsFromDB(_config, _sensors, run_number, true);
-	}
 
 	if (_firstEvent[ifile]){
 		//Run info


### PR DESCRIPTION
This PR makes the program compatible with different detectors (so far we only have NEW and DEMO++). In the normal mode (using DB) it will read the number of PMTs and SiPMs from the table `ChannelMapping` in the DB specified in the configuration of the job (by default NEWDB).

To distinguish between PMTs and SiPMs it will check whether the id is lower/higher than a threshold, currently set to 90 (should be enough for NEXT100 too).

The numbering pattern is from 0 to N for PMTs and `1000*dice_number`  to `1000*dice_number+63` for each SiPM dice board.

The only requisite for this to work is to have a working `ChannelMapping` table in the DB with the proper number of sensors.